### PR TITLE
Make description optional for asset schema

### DIFF
--- a/src/schemas/asset.ts
+++ b/src/schemas/asset.ts
@@ -18,7 +18,7 @@ const _assetSchema = z.object({
   }),
   fields: z.object({
     title: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
     file: fileSchema,
   }),
 });

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export function isZodOptionalSchema(zodSchema: z.ZodType): zodSchema is z.ZodOptional<z.ZodType> {
+    return (zodSchema._def as any).typeName === 'ZodOptional';
+}

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ export const contentfulImageSchema = z.object({
   }),
     fields: z.object({
     title: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
     file: z.object({
     url: z.string(),
     details: z.object({

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -134,7 +134,7 @@ const _baseSEO = z.object({
     fields: z.object({
     title: z.string().optional(),
     description: z.string().optional(),
-    image: contentfulImageSchema
+    image: contentfulImageSchema.optional()
   })
   });
 

--- a/test/fixtures/contentful.json
+++ b/test/fixtures/contentful.json
@@ -451,7 +451,7 @@
           "name": "Image",
           "type": "Link",
           "localized": false,
-          "required": true,
+          "required": false,
           "validations": [
             {
               "linkMimetypeGroup": ["image"]


### PR DESCRIPTION
### Problem

The description field is optional in Contentful, so it should be optional in the schema.

### Solution

Updates the description field to be an optional string. Updates the test snapshot also.

### Reference

Example Asset in Contentful

<img width="365" height="731" alt="CleanShot 2025-08-28 at 20 03 38" src="https://github.com/user-attachments/assets/a8b0e0c7-6c40-48d4-94fc-ab0fe91a261c" />

Output from running `Contentful-to-Zod` in Astro on a valid entry

<img width="895" height="65" alt="image" src="https://github.com/user-attachments/assets/daa99734-83b6-4bb6-9ec6-1409532c55d3" />
