### PR TITLE
Update contentful command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ contentful space export \
   --space-id <SPACE_ID> \
   --management-token <MANAGEMENT_TOKEN> \
   --content-file ./contentful.json \
-  --content-model-only=true
+  --skip-content
 ```
 
 ### ⚡️ Generate Schemas


### PR DESCRIPTION
`--content-model-only` is an import flag, it has no effect when exporting the content, making the command to run unnecessarily long. Use `--skip-content` instead.

Ref: https://www.contentful.com/developers/docs/tutorials/cli/import-and-export/#export-content