### PR TITLE
Add support for `in` validation with Zod enum Type

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -105,6 +105,10 @@ function zodToString(schema: unknown, config: ResolvedGeneratorConfig): string {
         .join(", ")}])`;
       break;
 
+    case "ZodEnum":
+      result = `z.enum(${JSON.stringify(schema._def.values)})`;
+      break;
+
     default:
       if (config.abortOnUnknown) {
         throw new Error(`Unsupported Zod type: ${schema._def.typeName}`);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -97,7 +97,13 @@ function getZodSchemaForFieldType({
   switch (type) {
     case "Symbol":
     case "Text": {
-      schema = z.string();
+      for (const validation of field.validations ?? []) {
+        if (validation.in) {
+          schema = z.enum(validation.in);
+          break;
+        }
+      }
+      schema ??= z.string();
       break;
     }
     case "Integer":

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -437,7 +437,7 @@ const _baseFormCard = z.object({
     fields: z.object({
     title: z.string(),
     body: contentfulRichTextSchema,
-    form: z.string()
+    form: z.enum(["contact","influencer-collaboration","influencer-signup","panel-feedback","panel-signup","brand-request","optimization-request"])
   })
   });
 


### PR DESCRIPTION
## Problem

Contentful allows validation on `Text` and `Symbol` fields to restrict values to a predefined array using the `in` validation rule. Currently, these fields are typed as `string`, missing an opportunity for stronger type safety that could be achieved by mapping them to Zod enum types.

## Solution

When a Contentful `Symbol` or `Text` field has an `in` validation rule present, the generated schema now returns a `Zod.enum()` type instead of a generic string type. This provides better type inference.