### PR TITLE
fix: wrap optional arrays in ZodArray in schema

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -227,13 +227,23 @@ export function printTypescriptSchemas(
             ? value._references
             : [];
           if (references.length > 0) {
+            const isOptional = "typeName" in value._def && value._def.typeName === "ZodOptional";
+            let isMultiple = "typeName" in value._def && value._def.typeName === "ZodArray";
+
+            /**
+             * Optional arrays have structure: ZodOptional<ZodArray<T>>
+             * Check ZodOptional's inner type to detect arrays when required=false
+             * (e.g., Contentful Array fields with required: false)
+             */
+            if (isOptional) {
+              const innerType = value._def.innerType;
+              isMultiple = "typeName" in innerType._def && innerType._def.typeName === "ZodArray";
+            }
+
             acc.set(field, {
               types: references,
-              multiple:
-                "typeName" in value._def && value._def.typeName === "ZodArray",
-              optional:
-                "typeName" in value._def &&
-                value._def.typeName === "ZodOptional",
+              multiple: isMultiple,
+              optional: isOptional,
             });
           }
           return acc;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -157,15 +157,18 @@ const _baseHero = z.object({
     fields: z.object({
     title: z.string(),
     body: contentfulRichTextSchema,
-    cta: z.unknown()
+    cta: z.unknown(),
+    relatedLinks: z.unknown()
   })
   });
 
-export type Hero = z.infer<typeof _baseHero> & { fields: {cta?: (Link | undefined)} };
+export type Hero = z.infer<typeof _baseHero> & { fields: {cta?: (Link | undefined),
+relatedLinks?: (Link | undefined)[]} };
 
 export const heroSchema: z.ZodType<Hero> = _baseHero.extend({
           fields: _baseHero.shape.fields.extend({
-            cta: z.lazy(() => linkSchema).optional()
+            cta: z.lazy(() => linkSchema).optional(),
+relatedLinks: z.lazy(() => z.array(linkSchema)).optional()
           })
         });
 

--- a/test/fixtures/contentful.json
+++ b/test/fixtures/contentful.json
@@ -575,6 +575,25 @@
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
+        },
+        {
+          "id": "relatedLinks",
+          "name": "Related Links",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": ["link"]
+              }
+            ],
+            "linkType": "Entry"
+          }
         }
       ]
     },


### PR DESCRIPTION
When a Contentful field is both optional (required: false) and array, the generated Zod schema was missing the z.array() wrapper. This occurred because optional arrays have the structure ZodOptional<ZodArray<T>>, where the array type is nested inside the optional wrapper.

The parser only checked the outer type (ZodOptional) when detecting if a field should be wrapped in z.array(), missing the inner ZodArray type.

This fix checks the inner type when a field is optional, correctly detecting arrays and generating schemas like:
    z.lazy(() => z.array(schema)).optional()
instead of:
    z.lazy(() => schema).optional()

Updated test fixtures to include an optional array field for coverage.