### PR TITLE
feat: support timezone offsets in Date fields

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -63,12 +63,15 @@ function zodToString(schema: unknown, config: ResolvedGeneratorConfig): string {
 
     case "ZodString":
       result = "z.string()";
-      if (
-        schema._def.checks?.some(
-          (check: z.ZodStringCheck) => check.kind === "datetime"
-        )
-      ) {
-        result += ".datetime()";
+      const datetimeCheck = schema._def.checks?.find(
+        (check: z.ZodStringCheck) => check.kind === "datetime"
+      );
+      if (datetimeCheck) {
+        if (datetimeCheck.offset) {
+          result += ".datetime({ offset: true })";
+        } else {
+          result += ".datetime()";
+        }
       }
       break;
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -116,7 +116,7 @@ function getZodSchemaForFieldType({
       break;
     }
     case "Date": {
-      schema = z.string().datetime();
+      schema = z.string().datetime({ offset: true });
       break;
     }
     case "RichText": {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -624,7 +624,9 @@ const _baseSettings = z.object({
   }),
     fields: z.object({
     name: z.string(),
-    configuration: z.unknown()
+    configuration: z.unknown(),
+    startDate: z.string().datetime({ offset: true }),
+    endDate: z.string().datetime({ offset: true }).optional()
   })
   });
 

--- a/test/fixtures/contentful-settings.json
+++ b/test/fixtures/contentful-settings.json
@@ -20,6 +20,18 @@
           "name": "Configuration",
           "type": "Object",
           "required": true
+        },
+        {
+          "id": "startDate",
+          "name": "Start Date",
+          "type": "Date",
+          "required": true
+        },
+        {
+          "id": "endDate",
+          "name": "End Date",
+          "type": "Date",
+          "required": false
         }
       ]
     }


### PR DESCRIPTION
Contentful Date fields with "Date and time with timezone" format store values like `2026-03-10T12:00:00+01:00`. Zod's `.datetime()` rejects these by default, only accepting the `Z` suffix.

Change Date field schema from `z.string().datetime()` to `z.string().datetime({ offset: true })` so both `Z` and `+HH:MM` timezone formats are accepted.